### PR TITLE
WooCommerce 3.0 compatability fix for accessing order properties

### DIFF
--- a/classes/class-wc-invoice-gateway.php
+++ b/classes/class-wc-invoice-gateway.php
@@ -262,7 +262,7 @@ class WC_Gateway_Invoice extends WC_Payment_Gateway {
    * @param bool $plain_text
    */
   public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
-    if ( $this->instructions && ! $sent_to_admin && 'invoice' === $order->payment_method && apply_filters( 'wc_invoice_gateway_process_payment_order_status', $this->order_status ) !== $order->payment_status ) {
+    if ( $this->instructions && ! $sent_to_admin && 'invoice' === $order->get_payment_method() && apply_filters( 'wc_invoice_gateway_process_payment_order_status', $this->order_status ) !== $order->get_status() ) {
       echo wpautop( wptexturize( $this->instructions ) ) . PHP_EOL;
     }
   }


### PR DESCRIPTION
After upgrading to WooCommerce 3.0, this plugin began throwing errors in the email_instructions function.  Changed the order properties payment_method and payment_status from being accessed directly to used the object getter functions.

I had trouble finding any reference to the $order->payment_status property. I assume it is meant to get the $order->status property.

This is my first public pull request. I wasn't sure if I should update version numbers or changelogs, so I left those as-is.